### PR TITLE
Solved #issue 3 Fix Text Wrapping in Home Page Card Section [GSSOC'23]

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -951,6 +951,7 @@ ul.top-links li {
     color: #fff;
     text-transform: capitalize;
     padding: 10px 20px;
+		white-space: nowrap;
 }
 @media(max-width:480px) {
 .agile-dish-caption {


### PR DESCRIPTION
[fix] Fix wrapping Instagram Caption in Card Section.
Fixed the Text Wrapping bug in Card Section that occurs on resizing the browser window.
@GSSOC'23